### PR TITLE
Replace invalid UTF-8 characters in redis key names when scanning keyspace

### DIFF
--- a/rma/scanner.py
+++ b/rma/scanner.py
@@ -93,7 +93,7 @@ class Scanner(object):
                 to_id = redis_type_to_id(key_type)
                 if to_id in self.accepted_types:
                     key_info_obj = {
-                        'name': key_name.decode("utf-8"),
+                        'name': key_name.decode("utf-8", "replace"),
                         'type': to_id,
                         'encoding': redis_encoding_str_to_id(key_encoding)
                     }


### PR DESCRIPTION
Keys in redis are binary-safe :
>Redis keys are binary safe, this means that you can use any binary sequence as a key, from a string like "foo" to the content of a JPEG file. The empty string is also a valid key.

That means that usually keys are in UTF-8, but can use any encoding, or no encoding at all. Since guessing character encoding can be a nightmare, I think the best course of action would be to replace invalid characters. In the final report these characters would not be displayable anyway.

Fixes #26 