### PR TITLE
Add "--max-key-depth" argument to help manage large amounts of key nesting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,6 +61,10 @@ After install used it from console:
                                  not specified, all data types will be returned.
                                  Allowed values arestring, hash, list, set, zset
       -f --format TYPE           Output type format: json or text (by default)
+     --max-key-depth MAX_DEPTH   Set the maximum depth to consider when
+                                 consolidating key segments (split by ":"). Any
+                                 segments past this depth will be squished into
+                                 a single "*".      
 
 If you have large database try running first with ``--limit`` option to
 run first limited amount of keys. Also run with ``--types`` to limit
@@ -70,6 +74,29 @@ queue with LUA (like in scanner does). So this option may be very
 useful. You can choose what kind of data would be aggregated from Redis
 node using ``-b (--behaviour)`` option as console argument. Supported
 behaviours are 'global', 'scanner', 'ram' and 'all'.
+
+The tool attempts to detect keys structured in a hierarchy (with ":" as the
+separating character) and consolidate them. Segments that look to be variable
+(currently any segments containing numbers) are consolidated together and
+represented with a single "*". The --max-key-depth argument allows you to
+specify how many levels should be considered before consolidating all of the
+remaining elements with a single "*".
+
+For example, if your keys are:
+
+    PREFIX                 -->   PREFIX
+    PREFIX:abc123          -->   PREFIX:*
+    PREFIX:def987          -->   PREFIX:*
+    PREFIX:abc123:SUFFIX   -->   PREFIX:*:SUFFIX
+    PREFIX:def987:SUFFIX   -->   PREFIX:*:SUFFIX
+
+However, if you pass --max-key-depth 1, these would be consolidated into:
+
+    PREFIX                 -->   PREFIX
+    PREFIX:abc123          -->   PREFIX:*
+    PREFIX:def987          -->   PREFIX:*
+    PREFIX:abc123:SUFFIX   -->   PREFIX:*
+    PREFIX:def987:SUFFIX   -->   PREFIX:*
 
 Internals
 ---------

--- a/rma/application.py
+++ b/rma/application.py
@@ -79,7 +79,7 @@ class RmaApplication(object):
         REDIS_TYPE_ID_ZSET: [],
     }
 
-    def __init__(self, host="127.0.0.1", port=6367, password=None, db=0, match="*", limit=0, filters=None, logger=None, format="text"):
+    def __init__(self, host="127.0.0.1", port=6367, password=None, db=0, match="*", limit=0, filters=None, logger=None, format="text", max_key_depth=None):
         self.logger = logger or logging.getLogger(__name__)
 
         self.splitter = SimpleSplitter()
@@ -89,6 +89,7 @@ class RmaApplication(object):
 
         self.match = match
         self.limit = limit if limit != 0 else sys.maxsize
+        self.max_key_depth = max_key_depth
 
         if 'types' in filters:
             self.types = list(map(redis_type_to_id, filters['types']))
@@ -178,7 +179,7 @@ class RmaApplication(object):
         return {"stat": ret}
 
     def get_pattern_aggregated_data(self, data):
-        split_patterns = self.splitter.split((ptransform(obj["name"]) for obj in data))
+        split_patterns = self.splitter.split([ptransform(obj["name"]) for obj in data], max_depth=self.max_key_depth)
         self.logger.debug(split_patterns)
 
         aggregate_patterns = {item: [] for item in split_patterns}

--- a/rma/cli/rma_cli.py
+++ b/rma/cli/rma_cli.py
@@ -70,6 +70,12 @@ def main():
                         dest="format",
                         default="text",
                         help="Output type format: json or text (by default)")
+    parser.add_argument("--max-key-depth",
+                        dest="max_key_depth",
+                        default="0",
+                        type=int,
+                        help="""Set the maximum depth to consider when consolidating key segments (split by ":").  Any segments past
+                                this depth will be squished into a single "*".""")
 
     options = parser.parse_args()
 
@@ -91,7 +97,8 @@ def main():
                 filters['types'].append(x)
 
     app = RmaApplication(host=options.host, port=options.port, db=options.db, password=options.password,
-                         match=options.match, limit=options.limit, filters=filters, format=options.format)
+                         match=options.match, limit=options.limit, filters=filters, format=options.format,
+                         max_key_depth=options.max_key_depth)
 
     start_time = time.clock()
     app.run()

--- a/rma/splitter.py
+++ b/rma/splitter.py
@@ -24,10 +24,20 @@ def map_part_to_glob(index, part):
 
     return part
 
+def pass1_func( separator, max_depth ):
+    def f(x):
+        ret = []
+        for i,y in enumerate(x.split(separator)):
+            globbed = map_part_to_glob(i, y)
+            ret.append( globbed )
+        if max_depth and len(ret) > max_depth:
+            ret = ret[0:max_depth] + ["*"]
+        return ret
+    return f
 
 class SimpleSplitter(object):
-    def split(self, data, separator=":"):
-        pass1 = map(lambda x: list(map_part_to_glob(i, y) for i, y in enumerate(x.split(separator))), data)
+    def split(self, data, separator=":", max_depth=None):
+        pass1 = map(pass1_func(separator, max_depth), data)
         pass2 = self.fold_to_tree(pass1)
         return self.unfold_to_list(pass2, separator)
 


### PR DESCRIPTION
Help when redis namespace is filled with a lot of multiple-level nested keys.

Instead of:

PREFIX:a:b:c
PREFIX:d:e:f
PREFIX:z:y:x

You can limit to 1:

PREFIX:*

Limit to 2:

PREFIX:a:*
PREFIX:d:*
PREFIX:z:*