### PR TITLE
Move calculation of size data for string, int, and list types into resolve_types LUA script

### DIFF
--- a/rma/application.py
+++ b/rma/application.py
@@ -124,7 +124,7 @@ class RmaApplication(object):
         is_all = self.behaviour == 'all'
         with Scanner(redis=self.redis, match=self.match, accepted_types=self.types) as scanner:
             keys = defaultdict(list)
-            for v in scanner.scan(limit=self.limit):
+            for v in scanner.scan(limit=self.limit, calculate_sizes=(is_all or self.behaviour == 'ram')):
                 keys[v["type"]].append(v)
 
             if self.isTextFormat:

--- a/rma/redis.py
+++ b/rma/redis.py
@@ -98,16 +98,16 @@ def ziplist_overhead(size):
     return Jemalloc.align(12 + 21 * size)
 
 
-def size_of_ziplist_aligned_string(value):
-    # Looks like we need something more complex here. We use calculation as 21 bytes per entry + len of string
-    # or len of pointer. Redis use more RAM saving policy but after aligning it has infelicity ~3-5%
-    try:
-        num_value = int(value)
-        return Jemalloc.align(size_of_pointer_fn())
-    except ValueError:
-        pass
+def size_of_ziplist_aligned_string(value_length):
+#    # Looks like we need something more complex here. We use calculation as 21 bytes per entry + len of string
+#    # or len of pointer. Redis use more RAM saving policy but after aligning it has infelicity ~3-5%
+#    try:
+#        num_value = int(value)
+#        return Jemalloc.align(size_of_pointer_fn())
+#    except ValueError:
+#        pass
 
-    return Jemalloc.align(len(value))
+    return Jemalloc.align(value_length)
 
 
 def linkedlist_overhead():
@@ -121,9 +121,8 @@ def linkedlist_entry_overhead():
     return 3*size_of_pointer_fn()
 
 
-def size_of_linkedlist_aligned_string(value):
-    return Jemalloc.align(linkedlist_entry_overhead() + len(value))
-
+def size_of_linkedlist_aligned_string(value_length):
+    return Jemalloc.align(linkedlist_entry_overhead() + value_length)
 
 def intset_overhead(size):
     #     typedef struct intset {

--- a/rma/rule/List.py
+++ b/rma/rule/List.py
@@ -15,20 +15,20 @@ class ListStatEntry(object):
         key_name = info["name"]
         self.encoding = info['encoding']
         self.ttl = info['ttl']
+        self.entry_lengths = info['len']
 
-        self.values = redis.lrange(key_name, 0, -1)
-        self.count = len(self.values)
+        self.count = len(self.entry_lengths)
         import time
         time.sleep(0.001)
-        used_bytes_iter, min_iter, max_iter = tee((len(x) for x in self.values), 3)
+        used_bytes_iter, min_iter, max_iter = tee(self.entry_lengths, 3)
 
         if self.encoding == REDIS_ENCODING_ID_LINKEDLIST:
             self.system = dict_overhead(self.count)
-            self.valueAlignedBytes = sum(map(size_of_linkedlist_aligned_string, self.values))
+            self.valueAlignedBytes = sum(map(size_of_linkedlist_aligned_string, self.entry_lengths))
         elif self.encoding == REDIS_ENCODING_ID_ZIPLIST or self.encoding == REDIS_ENCODING_ID_QUICKLIST:
             # Undone `quicklist`
             self.system = ziplist_overhead(self.count)
-            self.valueAlignedBytes = sum(map(size_of_ziplist_aligned_string, self.values))
+            self.valueAlignedBytes = sum(map(size_of_ziplist_aligned_string, self.entry_lengths))
         else:
             raise Exception('Panic', 'Unknown encoding %s in %s' % (self.encoding, key_name))
 

--- a/rma/rule/ValueString.py
+++ b/rma/rule/ValueString.py
@@ -36,7 +36,7 @@ class RealStringEntry(object):
         self.logger = logging.getLogger(__name__)
 
         if self.encoding == REDIS_ENCODING_ID_INT:
-            self.useful_bytes = self.get_int_encoded_bytes(redis, key_name)
+            self.useful_bytes = info["len"]
             self.free_bytes = 0
             self.aligned = size_of_aligned_string_by_size(self.useful_bytes, encoding=self.encoding)
         elif self.encoding == REDIS_ENCODING_ID_EMBSTR or self.encoding == REDIS_ENCODING_ID_RAW:
@@ -45,7 +45,7 @@ class RealStringEntry(object):
                 self.useful_bytes = sdslen_response['val_sds_len']
                 self.free_bytes = sdslen_response['val_sds_avail']
             else:
-                self.useful_bytes = size_of_aligned_string_by_size(redis.strlen(key_name), self.encoding)
+                self.useful_bytes = info["len"]
                 self.free_bytes = 0
             # INFO Rewrite this to support Redis >= 3.2 sds dynamic header
             sds_len = 8 + self.useful_bytes + self.free_bytes + 1


### PR DESCRIPTION
On my test Redis instance (~4 million entries), this resulted in a *substantial* improvement in run-time, mainly by batching all of the calls into the same block of LUA as the existing resolve_types script.

As point of comparison, this code runs on my current instance in about 5 minutes. I gave up running the unmodified original code after 15 minutes, as the "Processing String patterns" step was only 1% of the way completed.

I did my best to keep the size calculations true to the original code, but I'm not 100% confident I am calculating exactly the same sizes as the original.