### PR TITLE
Add namespace separator argument for redis databases.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,6 +61,7 @@ After install used it from console:
                                  not specified, all data types will be returned.
                                  Allowed values arestring, hash, list, set, zset
       -f --format TYPE           Output type format: json or text (by default)
+      -x --separator SEPARATOR   Specify namespace separator. Default is ':'
 
 If you have large database try running first with ``--limit`` option to
 run first limited amount of keys. Also run with ``--types`` to limit

--- a/rma/application.py
+++ b/rma/application.py
@@ -79,10 +79,10 @@ class RmaApplication(object):
         REDIS_TYPE_ID_ZSET: [],
     }
 
-    def __init__(self, host="127.0.0.1", port=6367, password=None, db=0, match="*", limit=0, filters=None, logger=None, format="text"):
+    def __init__(self, host="127.0.0.1", port=6367, password=None, db=0, match="*", limit=0, filters=None, logger=None, format="text", separator=":"):
         self.logger = logger or logging.getLogger(__name__)
 
-        self.splitter = SimpleSplitter()
+        self.splitter = SimpleSplitter(separator)
         self.isTextFormat = format == "text"
         self.reporter = TextReporter() if self.isTextFormat else JsonReporter()
         self.redis = connect_to_redis(host=host, port=port, db=db, password=password)

--- a/rma/cli/rma_cli.py
+++ b/rma/cli/rma_cli.py
@@ -70,6 +70,10 @@ def main():
                         dest="format",
                         default="text",
                         help="Output type format: json or text (by default)")
+    parser.add_argument("-x", "--separator",
+                        dest="separator",
+                        default=":",
+                        help="Specify namespace separator. Default is ':'.")
 
     options = parser.parse_args()
 
@@ -91,7 +95,8 @@ def main():
                 filters['types'].append(x)
 
     app = RmaApplication(host=options.host, port=options.port, db=options.db, password=options.password,
-                         match=options.match, limit=options.limit, filters=filters, format=options.format)
+                         match=options.match, limit=options.limit, filters=filters, format=options.format,
+                         separator=options.separator)
 
     start_time = time.clock()
     app.run()

--- a/rma/cli/rma_cli.py
+++ b/rma/cli/rma_cli.py
@@ -73,7 +73,7 @@ def main():
     parser.add_argument("-x", "--separator",
                         dest="separator",
                         default=":",
-                        help="Specify namespace separator. Default is ':'.")
+                        help="Specify namespace separator. Default is ':'")
 
     options = parser.parse_args()
 

--- a/rma/splitter.py
+++ b/rma/splitter.py
@@ -26,10 +26,15 @@ def map_part_to_glob(index, part):
 
 
 class SimpleSplitter(object):
-    def split(self, data, separator=":"):
-        pass1 = map(lambda x: list(map_part_to_glob(i, y) for i, y in enumerate(x.split(separator))), data)
+    separator = ':'
+
+    def __init__(self, separator):
+        self.separator = separator
+
+    def split(self, data):
+        pass1 = map(lambda x: list(map_part_to_glob(i, y) for i, y in enumerate(x.split(self.separator))), data)
         pass2 = self.fold_to_tree(pass1)
-        return self.unfold_to_list(pass2, separator)
+        return self.unfold_to_list(pass2, self.separator)
 
     def fold_to_tree(self, pass1):
         tree = {}


### PR DESCRIPTION
Since redis does not strictly enforce colon as the namespace delimiter, it is possible to use a non-standard character such as a hyphen in practice.

Without the ability to provide a non-standard delimiter to the analyzer, every key is treated as unique and the profiler is unable to accurately print an analysis of the memory.