### PR TITLE
Calculate Idle Time for All KeyTypes and Display Statistics

### DIFF
--- a/rma/rule/ValueString.py
+++ b/rma/rule/ValueString.py
@@ -33,6 +33,7 @@ class RealStringEntry(object):
         key_name = info["name"]
         self.encoding = info["encoding"]
         self.ttl = info["ttl"]
+        self.idleTime = info["idleTime"]
         self.logger = logging.getLogger(__name__)
 
         if self.encoding == REDIS_ENCODING_ID_INT:
@@ -65,7 +66,7 @@ class ValueString(object):
 
     def analyze(self, keys, total=0):
         key_stat = {
-            'headers': ['Match', "Count", "Useful", "Free", "Real", "Ratio", "Encoding", "Min", "Max", "Avg", "TTL Min", "TTL Max", "TTL Avg"],
+            'headers': ['Match', "Count", "Useful", "Free", "Real", "Ratio", "Encoding", "Min", "Max", "Avg", "TTL Min", "TTL Max", "TTL Avg","idleTime Min", "idleTime Max", "idleTime Avg"],
             'data': []
         }
 
@@ -81,6 +82,7 @@ class ValueString(object):
             aligned_bytes = []
             encodings = []
             ttl = []
+            idleTime=[]
 
             for key_info in progress_iterator(data, progress):
                 try:
@@ -90,6 +92,7 @@ class ValueString(object):
                         aligned_bytes.append(stat.aligned)
                         encodings.append(stat.encoding)
                         ttl.append(stat.ttl)
+                        idleTime.append(stat.idleTime)
                 except RedisError as e:
                     # This code works in real time so key me be deleted and this code fail
                     error_string = repr(e)
@@ -111,6 +114,9 @@ class ValueString(object):
             min_ttl  = min(ttl) if len(ttl) >= 1 else -1
             max_ttl  = max(ttl) if len(ttl) >= 1 else -1
             mean_ttl = statistics.mean(ttl) if len(ttl) > 1 else min_ttl
+            min_idle_time = min(idleTime) if len(idleTime) >= 1 else -1
+            max_idle_time = max(idleTime) if len(idleTime) >= 1 else -1
+            mean_idle_time = statistics.mean(idleTime) if len(idleTime) > 1 else min_idle_time
 
             stat_entry = [
                 pattern,
@@ -126,11 +132,14 @@ class ValueString(object):
                 min_ttl,
                 max_ttl,
                 mean_ttl,
+                min_idle_time,
+                max_idle_time,
+                mean_idle_time,
             ]
             key_stat['data'].append(stat_entry)
 
         key_stat['data'].sort(key=lambda e: e[1], reverse=True)
-        key_stat['data'].append(make_total_row(key_stat['data'], ['Total:', sum, sum, 0, sum, 0, '', 0, 0, 0, min, max, math.nan]))
+        key_stat['data'].append(make_total_row(key_stat['data'], ['Total:', sum, sum, 0, sum, 0, '', 0, 0, 0, min, max, math.nan,min, max, math.nan]))
 
         progress.close()
 

--- a/rma/scanner.py
+++ b/rma/scanner.py
@@ -32,7 +32,8 @@ class Scanner(object):
                 local type = redis.call("TYPE", KEYS[i])
                 local encoding = redis.call("OBJECT", "ENCODING",KEYS[i])
                 local ttl = redis.call("TTL", KEYS[i])
-                ret[i] = {type["ok"], encoding, ttl}
+                local idleTime=redis.call("OBJECT", "IDLETIME",KEYS[i])
+                ret[i] = {type["ok"], encoding, ttl,idleTime}
             end
             return cmsgpack.pack(ret)
         """)
@@ -76,7 +77,8 @@ class Scanner(object):
             pipe.type(key)
             pipe.object('ENCODING', key)
             pipe.ttl(key)
-        key_with_types = [{'type': x, 'encoding': y, 'ttl': z} for x, y, z in chunker(pipe.execute(), 3)]
+            pipe.object('idletime', key)
+        key_with_types = [{'type': x, 'encoding': y, 'ttl': z,'idleTime':i} for x, y, z,i in chunker(pipe.execute(), 4)]
         return key_with_types
 
     def scan(self, limit=1000):
@@ -86,7 +88,7 @@ class Scanner(object):
             total = 0
             for key_tuple in self.batch_scan():
                 key_info, key_name = key_tuple
-                key_type, key_encoding, key_ttl = key_info
+                key_type, key_encoding, key_ttl,key_idle_time = key_info
                 if not key_name:
                     self.logger.warning(
                         '\r\nWarning! Scan iterator return key with empty name `` and type %s', key_type)
@@ -98,7 +100,8 @@ class Scanner(object):
                         'name': key_name.decode("utf-8", "replace"),
                         'type': to_id,
                         'encoding': redis_encoding_str_to_id(key_encoding),
-                        'ttl': key_ttl
+                        'ttl': key_ttl,
+                        'idleTime': key_idle_time
                     }
                     yield key_info_obj
 


### PR DESCRIPTION
Description:

This pull request introduces a new feature to the Redis Memory Analyzer, which calculates the idle time for all key types and displays the minimum, maximum, and mean idle times in the Key Statistics tables. This feature aims to help users better understand key usage patterns and make informed decisions when managing their Redis instances.

Use Case:
In certain projects, a single microservice may consume a large amount of memory in Redis by creating numerous keys. In such cases, users may choose to separate that microservice's Redis instance to better manage memory consumption. This feature will allow users to easily identify and clear keys associated with the microservice in the original Redis instance, freeing up memory.

By utilizing the idle time property, users can determine the key patterns that have not been accessed for an extended period of time. This information can then be used to decide which keys were used by the microservice in question and can be safely removed.

Changes:

Added functionality to calculate idle time for all key types
Updated the Key Statistics tables to display min, max, and mean idle times